### PR TITLE
Require node 18 minimum due to test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/hombach/ioBroker.tibberlink.git"
   },
   "engines": {
-    "node": ">= 16.4.0"
+    "node": ">= 18"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.4",


### PR DESCRIPTION
As your adapter is configured to be tested using node 18 and node 20 only this adapter must require node 18 minimum.

If you want to keep minimum node version 16 (which is end of life already) please drop this PR butt add node 16 to the testmatrix.

